### PR TITLE
Add CNAME file for custom domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+octocanvas.io


### PR DESCRIPTION
This pull request makes a small change by adding a `CNAME` file to the repository. This sets the custom domain for the site to `octocanvas.io`.