### PR TITLE
Remove environment variables from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,9 +32,6 @@ jobs:
         run: npm ci
       
       - name: Build site
-        env:
-          SITE: ${{ github.event.repository.owner.html_url }}
-          BASE_URL: /${{ github.event.repository.name }}
         run: npm run build
       
       - name: Upload artifact


### PR DESCRIPTION
This pull request makes a small change to the deployment workflow configuration. The environment variables `SITE` and `BASE_URL` are no longer set during the site build step in `.github/workflows/deploy.yml`, since they are already hardcoded in the Astro config of the app.