### PR TITLE
Fix wallpaper download is ignoring selected background theme

### DIFF
--- a/src/components/WallpaperGenerator.tsx
+++ b/src/components/WallpaperGenerator.tsx
@@ -135,7 +135,7 @@ const WallpaperGenerator = forwardRef<
       handleThreadsShare,
       handleInstagramShare,
     }),
-    []
+    [selectedTheme, avatarFilter, user, avatarBase64]
   );
 
   /**


### PR DESCRIPTION
Fixes an issue where downloaded wallpaper png files were always using the default green theme background.