### PR TITLE
Migrate pull request automation away from pull_request_target

### DIFF
--- a/.github/workflows/dependabot-automerge-writer.yml
+++ b/.github/workflows/dependabot-automerge-writer.yml
@@ -1,0 +1,192 @@
+name: Dependabot auto-merge writer
+
+on:
+  workflow_run:
+    workflows: [Dependabot auto-merge]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+jobs:
+  approve-and-automerge:
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Dependabot metadata
+        id: artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/dependabot-automerge"
+          artifact_id="$(gh api "repos/$REPOSITORY/actions/runs/$RUN_ID/artifacts" \
+            --jq '.artifacts[] | select(.name == "dependabot-automerge-metadata" and .expired == false) | .id' | head -n 1)"
+          if [ -z "$artifact_id" ]; then
+            echo "No Dependabot automerge artifact found for run $RUN_ID"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          gh api "repos/$REPOSITORY/actions/artifacts/$artifact_id/zip" > "$RUNNER_TEMP/dependabot-automerge/artifact.zip"
+          unzip -p "$RUNNER_TEMP/dependabot-automerge/artifact.zip" dependabot-automerge-metadata.json > "$RUNNER_TEMP/dependabot-automerge/metadata.json"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+      - name: Approve and enable auto-merge
+        if: steps.artifact.outputs.found == 'true'
+        uses: actions/github-script@v9
+        env:
+          METADATA_PATH: ${{ runner.temp }}/dependabot-automerge/metadata.json
+        with:
+          script: |
+            const fs = require('fs');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const expectedRepo = `${owner}/${repo}`;
+            const run = context.payload.workflow_run;
+            const runPr = Array.isArray(run.pull_requests) && run.pull_requests[0];
+            if (!runPr || !runPr.number) {
+              core.info('Workflow run is not associated with a pull request; skipping.');
+              return;
+            }
+            if (run.actor && run.actor.login !== 'dependabot[bot]') {
+              core.info(`Workflow run actor is ${run.actor.login}; skipping.`);
+              return;
+            }
+
+            const metadata = JSON.parse(fs.readFileSync(process.env.METADATA_PATH, 'utf8'));
+            validateMetadataIdentity(metadata, runPr.number);
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: runPr.number,
+            });
+
+            if (pr.state !== 'open') {
+              core.info(`PR #${pr.number} is ${pr.state}; skipping.`);
+              return;
+            }
+            if (pr.user.login !== 'dependabot[bot]') {
+              core.info(`PR author is ${pr.user.login}; skipping.`);
+              return;
+            }
+            if (pr.base.repo.full_name !== expectedRepo) {
+              throw new Error(`Unexpected base repository: ${pr.base.repo.full_name}`);
+            }
+            if (!pr.head.repo || pr.head.repo.full_name !== expectedRepo) {
+              throw new Error(`Dependabot PR head must be in ${expectedRepo}; got ${pr.head.repo && pr.head.repo.full_name}`);
+            }
+            if (metadata.headSha !== pr.head.sha) {
+              core.info(`Stale metadata for ${metadata.headSha}; current PR head is ${pr.head.sha}.`);
+              return;
+            }
+
+            if (!validateNonMajorUpdate(metadata)) {
+              return;
+            }
+
+            const headSha = pr.head.sha;
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number: pr.number,
+              commit_id: headSha,
+              event: 'APPROVE',
+              body: `Auto-approving Dependabot ${metadata.updateType} update for ${metadata.dependencyNames || 'dependencies'}.`,
+            });
+            core.info(`Approved PR #${pr.number} at ${headSha}.`);
+
+            const { data: afterApproval } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pr.number,
+            });
+            if (afterApproval.head.sha !== headSha) {
+              throw new Error(`PR head changed after approval (${headSha} -> ${afterApproval.head.sha}); not enabling auto-merge.`);
+            }
+
+            if (afterApproval.auto_merge) {
+              core.info('Auto-merge is already enabled.');
+              return;
+            }
+
+            const mutation = `
+              mutation($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId,
+                  mergeMethod: SQUASH,
+                  expectedHeadOid: $expectedHeadOid
+                }) {
+                  pullRequest {
+                    number
+                    autoMergeRequest { enabledAt mergeMethod }
+                  }
+                }
+              }
+            `;
+            await github.graphql(mutation, {
+              pullRequestId: afterApproval.node_id,
+              expectedHeadOid: headSha,
+            });
+            core.info(`Enabled squash auto-merge for PR #${pr.number} at ${headSha}.`);
+
+            function validateMetadataIdentity(metadata, prNumber) {
+              if (!metadata || metadata.schema !== 'dependabot-automerge/v1') {
+                throw new Error('Unexpected metadata schema.');
+              }
+              if (metadata.repository !== expectedRepo || metadata.baseRepo !== expectedRepo || metadata.headRepo !== expectedRepo) {
+                throw new Error(`Metadata repository mismatch: ${metadata.repository}, base ${metadata.baseRepo}, head ${metadata.headRepo}`);
+              }
+              if (!Number.isInteger(metadata.prNumber) || metadata.prNumber !== prNumber) {
+                throw new Error(`Metadata PR mismatch: ${metadata.prNumber} !== ${prNumber}`);
+              }
+              if (metadata.prUser !== 'dependabot[bot]') {
+                throw new Error(`Metadata PR user mismatch: ${metadata.prUser}`);
+              }
+              if (!/^[0-9a-f]{40}$/i.test(metadata.headSha)) {
+                throw new Error('Metadata head SHA is invalid.');
+              }
+            }
+
+            function validateNonMajorUpdate(metadata) {
+              if (typeof metadata.updateType !== 'string' || metadata.updateType.length === 0) {
+                throw new Error('Dependabot update type is missing.');
+              }
+              if (metadata.updateType === 'version-update:semver-major') {
+                core.info('Dependabot update is semver-major; skipping auto-merge.');
+                return false;
+              }
+              if (!/^version-update:semver-(minor|patch)$/.test(metadata.updateType)) {
+                throw new Error(`Unsupported Dependabot update type: ${metadata.updateType}`);
+              }
+              if (typeof metadata.maintainerChanges === 'string' && metadata.maintainerChanges.toLowerCase() === 'true') {
+                throw new Error('Dependabot metadata reports maintainer changes; not auto-merging.');
+              }
+
+              let dependencies;
+              try {
+                dependencies = JSON.parse(metadata.updatedDependenciesJson || '[]');
+              } catch (err) {
+                throw new Error(`Invalid updated-dependencies-json: ${err.message}`);
+              }
+              if (!Array.isArray(dependencies) || dependencies.length === 0) {
+                throw new Error('Dependabot metadata did not include updated dependencies.');
+              }
+              for (const dep of dependencies) {
+                const depUpdateType = dep['update-type'] || dep.updateType;
+                if (depUpdateType === 'version-update:semver-major') {
+                  throw new Error(`Dependency ${dep['dependency-name'] || dep.dependencyName || '<unknown>'} is semver-major.`);
+                }
+                if (depUpdateType && !/^version-update:semver-(minor|patch)$/.test(depUpdateType)) {
+                  throw new Error(`Unsupported dependency update type: ${depUpdateType}`);
+                }
+              }
+              return true;
+            }

--- a/.github/workflows/dependabot-automerge-writer.yml
+++ b/.github/workflows/dependabot-automerge-writer.yml
@@ -15,6 +15,9 @@ jobs:
     if: >-
       ${{ github.event.workflow_run.conclusion == 'success' &&
           github.event.workflow_run.event == 'pull_request' }}
+    concurrency:
+      group: dependabot-automerge-${{ github.repository_id }}-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - name: Download Dependabot metadata
@@ -26,14 +29,25 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/dependabot-automerge"
-          artifact_id="$(gh api "repos/$REPOSITORY/actions/runs/$RUN_ID/artifacts" \
-            --jq '.artifacts[] | select(.name == "dependabot-automerge-metadata" and .expired == false) | .id' | head -n 1)"
-          if [ -z "$artifact_id" ]; then
+          mapfile -t artifact_ids < <(
+            gh api --paginate "repos/$REPOSITORY/actions/runs/$RUN_ID/artifacts?per_page=100" \
+              --jq '.artifacts[] | select(.name == "dependabot-automerge-metadata" and .expired == false) | .id'
+          )
+          if [ "${#artifact_ids[@]}" -eq 0 ]; then
             echo "No Dependabot automerge artifact found for run $RUN_ID"
             echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          gh api "repos/$REPOSITORY/actions/artifacts/$artifact_id/zip" > "$RUNNER_TEMP/dependabot-automerge/artifact.zip"
+          if [ "${#artifact_ids[@]}" -ne 1 ]; then
+            echo "Expected exactly one Dependabot automerge artifact for run $RUN_ID; found ${#artifact_ids[@]}" >&2
+            exit 1
+          fi
+          gh api "repos/$REPOSITORY/actions/artifacts/${artifact_ids[0]}/zip" > "$RUNNER_TEMP/dependabot-automerge/artifact.zip"
+          mapfile -t archive_entries < <(unzip -Z1 "$RUNNER_TEMP/dependabot-automerge/artifact.zip")
+          if [ "${#archive_entries[@]}" -ne 1 ] || [ "${archive_entries[0]}" != "dependabot-automerge-metadata.json" ]; then
+            echo "Dependabot automerge artifact must contain exactly dependabot-automerge-metadata.json" >&2
+            exit 1
+          fi
           unzip -p "$RUNNER_TEMP/dependabot-automerge/artifact.zip" dependabot-automerge-metadata.json > "$RUNNER_TEMP/dependabot-automerge/metadata.json"
           echo "found=true" >> "$GITHUB_OUTPUT"
 
@@ -49,19 +63,17 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const expectedRepo = `${owner}/${repo}`;
+            const expectedRepoId = context.payload.repository.id;
             const run = context.payload.workflow_run;
-            const runPr = Array.isArray(run.pull_requests) && run.pull_requests[0];
-            if (!runPr || !runPr.number) {
-              core.info('Workflow run is not associated with a pull request; skipping.');
-              return;
+            const runPullRequests = Array.isArray(run.pull_requests) ? run.pull_requests : [];
+            if (runPullRequests.length !== 1) {
+              throw new Error(`Expected workflow run to identify exactly one pull request; found ${runPullRequests.length}.`);
             }
-            if (run.actor && run.actor.login !== 'dependabot[bot]') {
-              core.info(`Workflow run actor is ${run.actor.login}; skipping.`);
-              return;
-            }
+            const runPr = runPullRequests[0];
+            validateWorkflowRun(run, runPr);
 
             const metadata = JSON.parse(fs.readFileSync(process.env.METADATA_PATH, 'utf8'));
-            validateMetadataIdentity(metadata, runPr.number);
+            validateMetadataIdentity(metadata, run, runPr);
 
             const { data: pr } = await github.rest.pulls.get({
               owner,
@@ -77,31 +89,50 @@ jobs:
               core.info(`PR author is ${pr.user.login}; skipping.`);
               return;
             }
-            if (pr.base.repo.full_name !== expectedRepo) {
+            if (pr.id !== runPr.id) {
+              throw new Error(`Workflow run PR id ${runPr.id} does not match current PR id ${pr.id}.`);
+            }
+            if (pr.base.repo.id !== expectedRepoId || pr.base.repo.full_name !== expectedRepo) {
               throw new Error(`Unexpected base repository: ${pr.base.repo.full_name}`);
             }
-            if (!pr.head.repo || pr.head.repo.full_name !== expectedRepo) {
+            if (!pr.head.repo || pr.head.repo.id !== expectedRepoId || pr.head.repo.full_name !== expectedRepo) {
               throw new Error(`Dependabot PR head must be in ${expectedRepo}; got ${pr.head.repo && pr.head.repo.full_name}`);
             }
-            if (metadata.headSha !== pr.head.sha) {
-              core.info(`Stale metadata for ${metadata.headSha}; current PR head is ${pr.head.sha}.`);
+            if (pr.head.sha !== run.head_sha) {
+              core.info(`Stale workflow run for ${run.head_sha}; current PR head is ${pr.head.sha}.`);
               return;
             }
 
-            if (!validateNonMajorUpdate(metadata)) {
+            const dependencies = validateNonMajorUpdate(metadata);
+            if (!dependencies) {
               return;
             }
 
             const headSha = pr.head.sha;
-            await github.rest.pulls.createReview({
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner,
               repo,
               pull_number: pr.number,
-              commit_id: headSha,
-              event: 'APPROVE',
-              body: `Auto-approving Dependabot ${metadata.updateType} update for ${metadata.dependencyNames || 'dependencies'}.`,
+              per_page: 100,
             });
-            core.info(`Approved PR #${pr.number} at ${headSha}.`);
+            const alreadyApproved = reviews.some((review) =>
+              review.user && review.user.login === 'github-actions[bot]' &&
+              review.state === 'APPROVED' &&
+              review.commit_id === headSha
+            );
+            if (alreadyApproved) {
+              core.info(`PR #${pr.number} is already approved by github-actions[bot] at ${headSha}.`);
+            } else {
+              await github.rest.pulls.createReview({
+                owner,
+                repo,
+                pull_number: pr.number,
+                commit_id: headSha,
+                event: 'APPROVE',
+                body: `Auto-approving Dependabot ${metadata.updateType} update for ${formatDependencySummary(dependencies)}.`,
+              });
+              core.info(`Approved PR #${pr.number} at ${headSha}.`);
+            }
 
             const { data: afterApproval } = await github.rest.pulls.get({
               owner,
@@ -137,25 +168,70 @@ jobs:
             });
             core.info(`Enabled squash auto-merge for PR #${pr.number} at ${headSha}.`);
 
-            function validateMetadataIdentity(metadata, prNumber) {
-              if (!metadata || metadata.schema !== 'dependabot-automerge/v1') {
+            function validateWorkflowRun(workflowRun, workflowRunPr) {
+              if (workflowRun.name !== 'Dependabot auto-merge' ||
+                  workflowRun.event !== 'pull_request' ||
+                  workflowRun.conclusion !== 'success') {
+                throw new Error(`Unexpected workflow run: ${workflowRun.name}, ${workflowRun.event}, ${workflowRun.conclusion}`);
+              }
+              if (!workflowRun.actor || workflowRun.actor.login !== 'dependabot[bot]' ||
+                  !workflowRun.triggering_actor || workflowRun.triggering_actor.login !== 'dependabot[bot]') {
+                throw new Error('Workflow run actor and triggering actor must both be dependabot[bot].');
+              }
+              if (!workflowRun.head_repository ||
+                  workflowRun.head_repository.id !== expectedRepoId ||
+                  workflowRun.head_repository.full_name !== expectedRepo) {
+                throw new Error(`Unexpected workflow run head repository: ${workflowRun.head_repository && workflowRun.head_repository.full_name}`);
+              }
+              if (!workflowRunPr || !Number.isInteger(workflowRunPr.number) || !Number.isInteger(workflowRunPr.id)) {
+                throw new Error('Workflow run pull request identity is invalid.');
+              }
+              if (!workflowRunPr.base || !workflowRunPr.base.repo ||
+                  workflowRunPr.base.repo.id !== expectedRepoId ||
+                  !workflowRunPr.head || !workflowRunPr.head.repo ||
+                  workflowRunPr.head.repo.id !== expectedRepoId) {
+                throw new Error('Workflow run pull request repositories do not match the current repository.');
+              }
+              if (workflowRun.head_sha !== workflowRunPr.head.sha) {
+                throw new Error(`Workflow run head ${workflowRun.head_sha} does not match associated PR head ${workflowRunPr.head.sha}.`);
+              }
+              if (!/^[0-9a-f]{40}$/i.test(workflowRun.head_sha)) {
+                throw new Error('Workflow run head SHA is invalid.');
+              }
+            }
+
+            function validateMetadataIdentity(metadata, workflowRun, workflowRunPr) {
+              if (!metadata || metadata.schema !== 'dependabot-automerge/v2') {
                 throw new Error('Unexpected metadata schema.');
               }
-              if (metadata.repository !== expectedRepo || metadata.baseRepo !== expectedRepo || metadata.headRepo !== expectedRepo) {
+              if (metadata.repository !== expectedRepo ||
+                  metadata.repositoryId !== expectedRepoId ||
+                  metadata.baseRepo !== expectedRepo ||
+                  metadata.baseRepoId !== expectedRepoId ||
+                  metadata.headRepo !== expectedRepo ||
+                  metadata.headRepoId !== expectedRepoId) {
                 throw new Error(`Metadata repository mismatch: ${metadata.repository}, base ${metadata.baseRepo}, head ${metadata.headRepo}`);
               }
-              if (!Number.isInteger(metadata.prNumber) || metadata.prNumber !== prNumber) {
-                throw new Error(`Metadata PR mismatch: ${metadata.prNumber} !== ${prNumber}`);
+              if (!Number.isInteger(metadata.workflowRunId) || metadata.workflowRunId !== workflowRun.id ||
+                  !Number.isInteger(metadata.workflowRunAttempt) || metadata.workflowRunAttempt !== workflowRun.run_attempt) {
+                throw new Error('Metadata workflow run identity does not match the triggering workflow run.');
+              }
+              if (!Number.isInteger(metadata.prNumber) || metadata.prNumber !== workflowRunPr.number ||
+                  !Number.isInteger(metadata.prId) || metadata.prId !== workflowRunPr.id) {
+                throw new Error(`Metadata PR mismatch: #${metadata.prNumber}/${metadata.prId} !== #${workflowRunPr.number}/${workflowRunPr.id}`);
               }
               if (metadata.prUser !== 'dependabot[bot]') {
                 throw new Error(`Metadata PR user mismatch: ${metadata.prUser}`);
               }
-              if (!/^[0-9a-f]{40}$/i.test(metadata.headSha)) {
-                throw new Error('Metadata head SHA is invalid.');
+              if (metadata.headSha !== workflowRun.head_sha) {
+                throw new Error(`Metadata head ${metadata.headSha} does not match workflow run head ${workflowRun.head_sha}.`);
               }
             }
 
             function validateNonMajorUpdate(metadata) {
+              if (metadata.maintainerChanges !== 'false') {
+                throw new Error('Dependabot metadata must explicitly report no maintainer changes.');
+              }
               if (typeof metadata.updateType !== 'string' || metadata.updateType.length === 0) {
                 throw new Error('Dependabot update type is missing.');
               }
@@ -166,27 +242,47 @@ jobs:
               if (!/^version-update:semver-(minor|patch)$/.test(metadata.updateType)) {
                 throw new Error(`Unsupported Dependabot update type: ${metadata.updateType}`);
               }
-              if (typeof metadata.maintainerChanges === 'string' && metadata.maintainerChanges.toLowerCase() === 'true') {
-                throw new Error('Dependabot metadata reports maintainer changes; not auto-merging.');
+              if (typeof metadata.updatedDependenciesJson !== 'string') {
+                throw new Error('Dependabot updated dependencies metadata is missing.');
               }
 
               let dependencies;
               try {
-                dependencies = JSON.parse(metadata.updatedDependenciesJson || '[]');
+                dependencies = JSON.parse(metadata.updatedDependenciesJson);
               } catch (err) {
                 throw new Error(`Invalid updated-dependencies-json: ${err.message}`);
               }
-              if (!Array.isArray(dependencies) || dependencies.length === 0) {
-                throw new Error('Dependabot metadata did not include updated dependencies.');
+              if (!Array.isArray(dependencies) || dependencies.length === 0 || dependencies.length > 1000) {
+                throw new Error('Dependabot metadata must include between 1 and 1000 updated dependencies.');
               }
               for (const dep of dependencies) {
+                if (!dep || typeof dep !== 'object' || Array.isArray(dep)) {
+                  throw new Error('Dependabot updated dependency entry is invalid.');
+                }
                 const depUpdateType = dep['update-type'] || dep.updateType;
                 if (depUpdateType === 'version-update:semver-major') {
                   throw new Error(`Dependency ${dep['dependency-name'] || dep.dependencyName || '<unknown>'} is semver-major.`);
                 }
-                if (depUpdateType && !/^version-update:semver-(minor|patch)$/.test(depUpdateType)) {
+                if (typeof depUpdateType !== 'string' || !/^version-update:semver-(minor|patch)$/.test(depUpdateType)) {
                   throw new Error(`Unsupported dependency update type: ${depUpdateType}`);
                 }
               }
-              return true;
+              return dependencies;
+            }
+
+            function formatDependencySummary(dependencies) {
+              const names = dependencies
+                .map((dep) => dep['dependency-name'] || dep.dependencyName)
+                .filter((name) => typeof name === 'string' && name.length > 0);
+              if (names.length === 0) {
+                return 'dependencies';
+              }
+              const shown = names.slice(0, 10).map((name) => {
+                const bounded = name.replace(/\s+/g, ' ').replace(/`/g, "'").slice(0, 80);
+                return `\`${bounded}\``;
+              });
+              if (names.length > shown.length) {
+                shown.push(`and ${names.length - shown.length} more`);
+              }
+              return shown.join(', ').slice(0, 1000);
             }

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -23,34 +23,40 @@ jobs:
         env:
           OUTPUT_PATH: ${{ runner.temp }}/dependabot-automerge-metadata.json
           REPOSITORY: ${{ github.repository }}
+          REPOSITORY_ID: ${{ github.repository_id }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          WORKFLOW_RUN_ATTEMPT: ${{ github.run_attempt }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_ID: ${{ github.event.pull_request.id }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          BASE_REPO_ID: ${{ github.event.pull_request.base.repo.id }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REPO_ID: ${{ github.event.pull_request.head.repo.id }}
           PR_USER: ${{ github.event.pull_request.user.login }}
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
-          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
-          PACKAGE_ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
-          DIRECTORY: ${{ steps.metadata.outputs.directory }}
           UPDATED_DEPENDENCIES_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
           MAINTAINER_CHANGES: ${{ steps.metadata.outputs.maintainer-changes }}
         run: |
           set -euo pipefail
           jq -n \
-            --arg schema 'dependabot-automerge/v1' \
+            --arg schema 'dependabot-automerge/v2' \
             --arg repository "$REPOSITORY" \
+            --argjson repositoryId "$REPOSITORY_ID" \
+            --argjson workflowRunId "$WORKFLOW_RUN_ID" \
+            --argjson workflowRunAttempt "$WORKFLOW_RUN_ATTEMPT" \
             --argjson prNumber "$PR_NUMBER" \
+            --argjson prId "$PR_ID" \
             --arg headSha "$HEAD_SHA" \
             --arg baseRepo "$BASE_REPO" \
+            --argjson baseRepoId "$BASE_REPO_ID" \
             --arg headRepo "$HEAD_REPO" \
+            --argjson headRepoId "$HEAD_REPO_ID" \
             --arg prUser "$PR_USER" \
             --arg updateType "$UPDATE_TYPE" \
-            --arg dependencyNames "$DEPENDENCY_NAMES" \
-            --arg packageEcosystem "$PACKAGE_ECOSYSTEM" \
-            --arg directory "$DIRECTORY" \
             --arg updatedDependenciesJson "$UPDATED_DEPENDENCIES_JSON" \
             --arg maintainerChanges "$MAINTAINER_CHANGES" \
-            '{schema: $schema, repository: $repository, prNumber: $prNumber, headSha: $headSha, baseRepo: $baseRepo, headRepo: $headRepo, prUser: $prUser, updateType: $updateType, dependencyNames: $dependencyNames, packageEcosystem: $packageEcosystem, directory: $directory, updatedDependenciesJson: $updatedDependenciesJson, maintainerChanges: $maintainerChanges}' \
+            '{schema: $schema, repository: $repository, repositoryId: $repositoryId, workflowRunId: $workflowRunId, workflowRunAttempt: $workflowRunAttempt, prNumber: $prNumber, prId: $prId, headSha: $headSha, baseRepo: $baseRepo, baseRepoId: $baseRepoId, headRepo: $headRepo, headRepoId: $headRepoId, prUser: $prUser, updateType: $updateType, updatedDependenciesJson: $updatedDependenciesJson, maintainerChanges: $maintainerChanges}' \
             > "$OUTPUT_PATH"
 
       - name: Upload metadata artifact

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,33 +1,62 @@
 name: Dependabot auto-merge
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
+
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
-  auto-merge:
+  metadata:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
 
-      - name: Auto-approve patch and minor updates
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr review --approve "$PR_URL"
+      - name: Write metadata artifact
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTPUT_PATH: ${{ runner.temp }}/dependabot-automerge-metadata.json
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          PACKAGE_ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          DIRECTORY: ${{ steps.metadata.outputs.directory }}
+          UPDATED_DEPENDENCIES_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
+          MAINTAINER_CHANGES: ${{ steps.metadata.outputs.maintainer-changes }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg schema 'dependabot-automerge/v1' \
+            --arg repository "$REPOSITORY" \
+            --argjson prNumber "$PR_NUMBER" \
+            --arg headSha "$HEAD_SHA" \
+            --arg baseRepo "$BASE_REPO" \
+            --arg headRepo "$HEAD_REPO" \
+            --arg prUser "$PR_USER" \
+            --arg updateType "$UPDATE_TYPE" \
+            --arg dependencyNames "$DEPENDENCY_NAMES" \
+            --arg packageEcosystem "$PACKAGE_ECOSYSTEM" \
+            --arg directory "$DIRECTORY" \
+            --arg updatedDependenciesJson "$UPDATED_DEPENDENCIES_JSON" \
+            --arg maintainerChanges "$MAINTAINER_CHANGES" \
+            '{schema: $schema, repository: $repository, prNumber: $prNumber, headSha: $headSha, baseRepo: $baseRepo, headRepo: $headRepo, prUser: $prUser, updateType: $updateType, dependencyNames: $dependencyNames, packageEcosystem: $packageEcosystem, directory: $directory, updatedDependenciesJson: $updatedDependenciesJson, maintainerChanges: $maintainerChanges}' \
+            > "$OUTPUT_PATH"
 
-      - name: Auto-merge patch and minor updates
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload metadata artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependabot-automerge-metadata
+          path: ${{ runner.temp }}/dependabot-automerge-metadata.json
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
## Summary

This draft updates the pull request automation in this repository to avoid using `pull_request_target` for PR-driven workflow execution.

The replacement pattern keeps untrusted PR input in lower-privilege `pull_request` workflows and moves any required repository-write actions into a separate, narrowly scoped follow-up path. Where a follow-up workflow is needed, it re-checks the pull request context before taking action so the workflow operates on the intended PR/head commit rather than trusting mutable PR state.

## Expected workflow shift

- PR-triggered jobs run with reduced permissions.
- Repository write actions, when still needed, happen after the PR workflow completes.
- Follow-up jobs validate PR metadata before posting labels, comments, statuses, or other write-side effects.
- Workflow behavior should remain equivalent for maintainers and contributors, with the permission boundary made more explicit.

## Notes

Opening as a draft for repository-owner review before this is marked ready. Please review the workflow-specific behavior and any repository settings assumptions before merge.
