### PR TITLE
Fix Open to Work badge export alignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@primer/react-brand": "^0.73.0",
         "astro": "^7.2.2",
         "framer-motion": "^13.1.0",
-        "html2canvas": "^1.4.1",
+        "modern-screenshot": "^4.7.0",
         "preact": "^10.29.8",
         "react": "^19.2.8",
         "react-social-icons": "^6.26.0",
@@ -3661,15 +3661,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.14",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
@@ -3953,15 +3944,6 @@
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
-      }
-    },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-select": {
@@ -4690,19 +4672,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "license": "MIT",
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -5265,6 +5234,12 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/modern-screenshot": {
+      "version": "4.7.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/modern-screenshot/-/modern-screenshot-4.7.0.tgz",
+      "integrity": "sha1-IvaDHeQd9XFyNaEZvNDMMJ2s96k=",
       "license": "MIT"
     },
     "node_modules/motion-dom": {
@@ -6116,15 +6091,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "utrie": "^1.0.2"
-      }
-    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -6519,15 +6485,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@primer/react-brand": "^0.73.0",
     "astro": "^7.2.2",
     "framer-motion": "^13.1.0",
-    "html2canvas": "^1.4.1",
+    "modern-screenshot": "^4.7.0",
     "preact": "^10.29.8",
     "react": "^19.2.8",
     "react-social-icons": "^6.26.0",

--- a/src/components/DevemonCard.module.css
+++ b/src/components/DevemonCard.module.css
@@ -70,7 +70,7 @@
   font-weight: bold;
   color: white;
   font-family: var(--font-family-mono);
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.25rem;
   line-height: 1.25;
 }
 
@@ -105,12 +105,6 @@
   letter-spacing: 0.05em;
   border-radius: 0.25rem;
   transition: all 200ms;
-}
-
-.RarityBadgeText {
-  display: block;
-  line-height: 1;
-  transform: translateY(-4px);
 }
 
 /* Avatar Section */
@@ -153,13 +147,11 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.25rem;
   padding: 0 0.5rem;
   height: 24px;
   font-family: var(--font-family-mono);
   font-weight: 500;
   font-size: 0.625rem;
-  line-height: 1;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   border-radius: 0.25rem;
@@ -171,43 +163,11 @@
 }
 
 .HireBadgeIcon {
-  position: relative;
-  display: block;
-  flex-shrink: 0;
-  width: 12px;
-  height: 10px;
-  box-sizing: border-box;
-  margin-top: 2px;
-  border: 1.5px solid currentColor;
-  border-radius: 2px;
-}
-
-.HireBadgeIconHandle {
-  position: absolute;
-  left: 3px;
-  top: -5px;
-  display: block;
-  width: 6px;
-  height: 5px;
-  box-sizing: border-box;
-  border: 1.5px solid currentColor;
-  border-bottom: 0;
-  border-radius: 2px 2px 0 0;
-}
-
-.HireBadgeIconSeam {
-  position: absolute;
-  left: -1.5px;
-  right: -1.5px;
-  top: 3px;
-  display: block;
-  border-top: 1.5px solid currentColor;
+  margin-right: 0.25rem;
 }
 
 .HireBadgeText {
-  display: block;
-  line-height: 1;
-  transform: translateY(-4px);
+  margin-left: 0.25rem;
 }
 
 /* Stats Section */
@@ -243,30 +203,11 @@
   gap: 0.25rem;
 }
 
-.StatLabelText {
-  display: block;
-  line-height: 1;
-  transform: translateY(-3px);
-}
-
 .StatValue {
   color: white;
   font-weight: bold;
   font-family: var(--font-family-mono);
   margin-top: 0.125rem;
-}
-
-.CardFooter {
-  margin-top: 0.75rem;
-  padding-top: 0.625rem;
-  border-top: 1px solid var(--color-border-tertiary);
-  text-align: center;
-}
-
-.CardFooterText {
-  color: #9ca3af;
-  font-size: 0.75rem;
-  font-family: var(--font-family-mono);
 }
 
 /* Controls Section */
@@ -399,7 +340,7 @@
   padding: 0.125rem 0.375rem;
   border-radius: 0.25rem;
   background-color: var(--color-brand-primary);
-  color: var(--color-brand-on-primary);
+  color: var(--color-bg-primary);
   margin-top: 0.25rem;
   display: inline-flex;
   align-items: center;

--- a/src/components/DevemonCard.module.css
+++ b/src/components/DevemonCard.module.css
@@ -110,7 +110,7 @@
 .RarityBadgeText {
   display: block;
   line-height: 1;
-  transform: translateY(-3px);
+  transform: translateY(-5px);
 }
 
 /* Avatar Section */
@@ -164,7 +164,7 @@
   letter-spacing: 0.05em;
   border-radius: 0.25rem;
   background-color: var(--color-brand-primary);
-  color: var(--color-brand-on-primary);
+  color: var(--color-bg-primary);
   border: 2px solid var(--color-bg-primary);
   white-space: nowrap;
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);

--- a/src/components/DevemonCard.module.css
+++ b/src/components/DevemonCard.module.css
@@ -107,6 +107,12 @@
   transition: all 200ms;
 }
 
+.RarityBadgeText {
+  display: block;
+  line-height: 1;
+  transform: translateY(-3px);
+}
+
 /* Avatar Section */
 .AvatarSection {
   display: flex;
@@ -201,7 +207,7 @@
 .HireBadgeText {
   display: block;
   line-height: 1;
-  transform: translateY(-1px);
+  transform: translateY(-4px);
 }
 
 /* Stats Section */
@@ -235,6 +241,12 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
+}
+
+.StatLabelText {
+  display: block;
+  line-height: 1;
+  transform: translateY(-3px);
 }
 
 .StatValue {

--- a/src/components/DevemonCard.module.css
+++ b/src/components/DevemonCard.module.css
@@ -70,7 +70,7 @@
   font-weight: bold;
   color: white;
   font-family: var(--font-family-mono);
-  margin-bottom: 0.25rem;
+  margin-bottom: 0.5rem;
   line-height: 1.25;
 }
 
@@ -110,7 +110,7 @@
 .RarityBadgeText {
   display: block;
   line-height: 1;
-  transform: translateY(-5px);
+  transform: translateY(-4px);
 }
 
 /* Avatar Section */

--- a/src/components/DevemonCard.module.css
+++ b/src/components/DevemonCard.module.css
@@ -147,11 +147,13 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 0.25rem;
   padding: 0 0.5rem;
   height: 24px;
   font-family: var(--font-family-mono);
   font-weight: 500;
   font-size: 0.625rem;
+  line-height: 1;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   border-radius: 0.25rem;
@@ -163,11 +165,43 @@
 }
 
 .HireBadgeIcon {
-  margin-right: 0.25rem;
+  position: relative;
+  display: block;
+  flex-shrink: 0;
+  width: 12px;
+  height: 10px;
+  box-sizing: border-box;
+  margin-top: 2px;
+  border: 1.5px solid currentColor;
+  border-radius: 2px;
+}
+
+.HireBadgeIconHandle {
+  position: absolute;
+  left: 3px;
+  top: -5px;
+  display: block;
+  width: 6px;
+  height: 5px;
+  box-sizing: border-box;
+  border: 1.5px solid currentColor;
+  border-bottom: 0;
+  border-radius: 2px 2px 0 0;
+}
+
+.HireBadgeIconSeam {
+  position: absolute;
+  left: -1.5px;
+  right: -1.5px;
+  top: 3px;
+  display: block;
+  border-top: 1.5px solid currentColor;
 }
 
 .HireBadgeText {
-  margin-left: 0.25rem;
+  display: block;
+  line-height: 1;
+  transform: translateY(-1px);
 }
 
 /* Stats Section */
@@ -208,6 +242,19 @@
   font-weight: bold;
   font-family: var(--font-family-mono);
   margin-top: 0.125rem;
+}
+
+.CardFooter {
+  margin-top: 0.75rem;
+  padding-top: 0.625rem;
+  border-top: 1px solid var(--color-border-tertiary);
+  text-align: center;
+}
+
+.CardFooterText {
+  color: #9ca3af;
+  font-size: 0.75rem;
+  font-family: var(--font-family-mono);
 }
 
 /* Controls Section */

--- a/src/components/DevemonCard.tsx
+++ b/src/components/DevemonCard.tsx
@@ -465,7 +465,9 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                       color: rarityInfo.color,
                     }}
                   >
-                    {rarityInfo.name.toUpperCase()}
+                    <span className={styles.RarityBadgeText}>
+                      {rarityInfo.name.toUpperCase()}
+                    </span>
                   </span>
                 </div>
               </div>
@@ -523,7 +525,7 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                         color="currentColor"
                         label="Repositories"
                       />
-                      Repositories
+                      <span className={styles.StatLabelText}>Repositories</span>
                     </div>
                     <div className={styles.StatValue}>{user.public_repos}</div>
                   </div>
@@ -535,7 +537,7 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                         color="currentColor"
                         label="Followers"
                       />
-                      Followers
+                      <span className={styles.StatLabelText}>Followers</span>
                     </div>
                     <div className={styles.StatValue}>{user.followers}</div>
                   </div>
@@ -547,7 +549,7 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                         color="currentColor"
                         label="Stars"
                       />
-                      Stars
+                      <span className={styles.StatLabelText}>Stars</span>
                     </div>
                     <div className={styles.StatValue}>
                       {extendedStats.totalStars}
@@ -561,7 +563,7 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                         color="currentColor"
                         label="Forks"
                       />
-                      Forks
+                      <span className={styles.StatLabelText}>Forks</span>
                     </div>
                     <div className={styles.StatValue}>
                       {extendedStats.totalForks}
@@ -578,7 +580,7 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                       color="currentColor"
                       label="Contributions"
                     />
-                    Contributions
+                    <span className={styles.StatLabelText}>Contributions</span>
                   </div>
                   <div className={styles.StatValue}>
                     {user.contributions?.totalContributions || 0}
@@ -595,7 +597,9 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                         color="currentColor"
                         label="Languages"
                       />
+                      <span className={styles.StatLabelText}>
                       Languages Mastered
+                      </span>
                     </div>
                     <div className="flex flex-wrap gap-1.5">
                       {extendedStats.topLanguages.map((lang) => (

--- a/src/components/DevemonCard.tsx
+++ b/src/components/DevemonCard.tsx
@@ -494,13 +494,14 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                   {availableForHire && (
                     <div className={styles.HireBadgeContainer}>
                       <span className={styles.HireBadge}>
-                        <Icon
-                          name="briefcase"
-                          size={12}
-                          color="currentColor"
-                          label=""
+                        <span
+                          aria-hidden="true"
+                          data-briefcase-icon="true"
                           className={styles.HireBadgeIcon}
-                        />
+                        >
+                          <span className={styles.HireBadgeIconHandle} />
+                          <span className={styles.HireBadgeIconSeam} />
+                        </span>
                         <span className={styles.HireBadgeText}>
                           OPEN TO WORK
                         </span>
@@ -611,8 +612,8 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
               </div>
 
               {/* Footer */}
-              <div className="mt-3 pt-2.5 border-t borderColor-muted text-center">
-                <p className="text-xs text-gray-400 font-mono">
+              <div className={styles.CardFooter}>
+                <p className={styles.CardFooterText}>
                   Developer since {formattedDate}
                 </p>
               </div>
@@ -803,11 +804,14 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                           display: "inline-flex",
                           alignItems: "center",
                           justifyContent: "center",
+                          gap: "4px",
                           padding: "0 8px",
                           height: "24px",
+                          boxSizing: "border-box",
                           fontFamily: "monospace",
                           fontWeight: "500",
                           fontSize: "9px",
+                          lineHeight: "1",
                           textTransform: "uppercase",
                           letterSpacing: "0.05em",
                           borderRadius: "4px",
@@ -818,19 +822,17 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                           boxShadow: "0 2px 4px rgba(0, 0, 0, 0.3)",
                         }}
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          viewBox="0 0 16 16"
-                          fill="currentColor"
-                          style={{
-                            width: "12px",
-                            height: "12px",
-                            marginRight: "4px",
-                          }}
+                        <span
+                          aria-hidden="true"
+                          data-briefcase-icon="true"
+                          className={styles.HireBadgeIcon}
                         >
-                          <path d="M7.5 1.75C7.5.784 8.284 0 9.25 0h5.5c.966 0 1.75.784 1.75 1.75v11.5A1.75 1.75 0 0 1 14.75 15h-5.5a1.75 1.75 0 0 1-1.75-1.75V1.75zm1.75-.25a.25.25 0 0 0-.25.25v11.5c0 .138.112.25.25.25h5.5a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25h-5.5zM4.943 9.25A.75.75 0 0 1 4 8.5h-.2a1.55 1.55 0 0 0-1.55 1.55v5.2c0 .856.694 1.55 1.55 1.55h.2a.75.75 0 0 1 0 1.5h-.2A3.05 3.05 0 0 1 .75 15.25v-5.2A3.05 3.05 0 0 1 3.8 7h.2a.75.75 0 0 1 .75.75v1.5z" />
-                        </svg>
-                        OPEN TO WORK
+                          <span className={styles.HireBadgeIconHandle} />
+                          <span className={styles.HireBadgeIconSeam} />
+                        </span>
+                        <span className={styles.HireBadgeText}>
+                          OPEN TO WORK
+                        </span>
                       </span>
                     </div>
                   )}

--- a/src/components/DevemonCard.tsx
+++ b/src/components/DevemonCard.tsx
@@ -18,6 +18,7 @@ import { Checkbox, PrimerSelect } from "./ui/FormControls";
 import { Button } from "./ui/Button";
 import styles from "./DevemonCard.module.css";
 import sharedStyles from "./shared.module.css";
+import { downloadElementAsPng, elementToPngBlob } from "../utils/domExport";
 
 interface DevemonCardProps {
   user: GitHubUser;
@@ -192,24 +193,10 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
       if (!targetRef.current) return;
 
       try {
-        const html2canvas = (await import("html2canvas")).default;
-        const canvas = await html2canvas(targetRef.current, {
-          backgroundColor: null,
-          scale: 3,
-          useCORS: true,
-          logging: false,
-        });
-
-        canvas.toBlob((blob) => {
-          if (blob) {
-            const url = URL.createObjectURL(blob);
-            const link = document.createElement("a");
-            link.href = url;
-            link.download = `devemon-${format}-${user.login}.png`;
-            link.click();
-            URL.revokeObjectURL(url);
-          }
-        }, "image/png");
+        await downloadElementAsPng(
+          targetRef.current,
+          `devemon-${format}-${user.login}.png`
+        );
       } catch (error) {
         console.error("Failed to download card:", error);
       }
@@ -222,43 +209,35 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
       if (!cardRef.current) return;
 
       try {
-        const html2canvas = (await import("html2canvas")).default;
-        const canvas = await html2canvas(cardRef.current, {
-          backgroundColor: null,
-          scale: 3,
-          useCORS: true,
-          logging: false,
-        });
+        const blob = await elementToPngBlob(cardRef.current);
 
-        canvas.toBlob(async (blob) => {
-          if (blob) {
-            try {
-              await navigator.clipboard.write([
-                new ClipboardItem({ "image/png": blob }),
-              ]);
+        if (blob) {
+          try {
+            await navigator.clipboard.write([
+              new ClipboardItem({ "image/png": blob }),
+            ]);
 
-              alert(
-                "✅ Devémon card copied to clipboard! You can now paste it in your tweet."
-              );
+            alert(
+              "✅ Devémon card copied to clipboard! You can now paste it in your tweet."
+            );
 
-              const tweetText =
-                "Just created my custom GitHub Universe Devémon card using Octocanvas from #GitHubUniverse 🎴";
-              const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-                tweetText
-              )}`;
-              window.open(
-                twitterUrl,
-                "twitter-share-dialog",
-                "width=626,height=436"
-              );
-            } catch (error) {
-              console.error("Error copying to clipboard:", error);
-              alert(
-                "Failed to copy card to clipboard. Please download it manually."
-              );
-            }
+            const tweetText =
+              "Just created my custom GitHub Universe Devémon card using Octocanvas from #GitHubUniverse 🎴";
+            const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+              tweetText
+            )}`;
+            window.open(
+              twitterUrl,
+              "twitter-share-dialog",
+              "width=626,height=436"
+            );
+          } catch (error) {
+            console.error("Error copying to clipboard:", error);
+            alert(
+              "Failed to copy card to clipboard. Please download it manually."
+            );
           }
-        }, "image/png");
+        }
       } catch (error) {
         console.error("Error sharing to Twitter:", error);
         alert("Failed to generate card image. Please try again.");
@@ -272,43 +251,35 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
       if (!cardRef.current) return;
 
       try {
-        const html2canvas = (await import("html2canvas")).default;
-        const canvas = await html2canvas(cardRef.current, {
-          backgroundColor: null,
-          scale: 3,
-          useCORS: true,
-          logging: false,
-        });
+        const blob = await elementToPngBlob(cardRef.current);
 
-        canvas.toBlob(async (blob) => {
-          if (blob) {
-            try {
-              await navigator.clipboard.write([
-                new ClipboardItem({ "image/png": blob }),
-              ]);
+        if (blob) {
+          try {
+            await navigator.clipboard.write([
+              new ClipboardItem({ "image/png": blob }),
+            ]);
 
-              alert(
-                "✅ Devémon card copied to clipboard! You can now paste it in your Bluesky post."
-              );
+            alert(
+              "✅ Devémon card copied to clipboard! You can now paste it in your Bluesky post."
+            );
 
-              const postText =
-                "Just created my custom GitHub Universe Devémon card using Octocanvas from #GitHubUniverse 🎴";
-              const blueskyUrl = `https://bsky.app/intent/compose?text=${encodeURIComponent(
-                postText
-              )}`;
-              window.open(
-                blueskyUrl,
-                "bluesky-share-dialog",
-                "width=626,height=600"
-              );
-            } catch (error) {
-              console.error("Error copying to clipboard:", error);
-              alert(
-                "Failed to copy card to clipboard. Please download it manually."
-              );
-            }
+            const postText =
+              "Just created my custom GitHub Universe Devémon card using Octocanvas from #GitHubUniverse 🎴";
+            const blueskyUrl = `https://bsky.app/intent/compose?text=${encodeURIComponent(
+              postText
+            )}`;
+            window.open(
+              blueskyUrl,
+              "bluesky-share-dialog",
+              "width=626,height=600"
+            );
+          } catch (error) {
+            console.error("Error copying to clipboard:", error);
+            alert(
+              "Failed to copy card to clipboard. Please download it manually."
+            );
           }
-        }, "image/png");
+        }
       } catch (error) {
         console.error("Error sharing to Bluesky:", error);
         alert("Failed to generate card image. Please try again.");
@@ -322,43 +293,35 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
       if (!cardRef.current) return;
 
       try {
-        const html2canvas = (await import("html2canvas")).default;
-        const canvas = await html2canvas(cardRef.current, {
-          backgroundColor: null,
-          scale: 3,
-          useCORS: true,
-          logging: false,
-        });
+        const blob = await elementToPngBlob(cardRef.current);
 
-        canvas.toBlob(async (blob) => {
-          if (blob) {
-            try {
-              await navigator.clipboard.write([
-                new ClipboardItem({ "image/png": blob }),
-              ]);
+        if (blob) {
+          try {
+            await navigator.clipboard.write([
+              new ClipboardItem({ "image/png": blob }),
+            ]);
 
-              alert(
-                "✅ Devémon card copied to clipboard! You can now paste it in your Threads post."
-              );
+            alert(
+              "✅ Devémon card copied to clipboard! You can now paste it in your Threads post."
+            );
 
-              const postText =
-                "Just created my custom GitHub Universe Devémon card using Octocanvas from #GitHubUniverse 🎴";
-              const threadsUrl = `https://www.threads.net/intent/post?text=${encodeURIComponent(
-                postText
-              )}`;
-              window.open(
-                threadsUrl,
-                "threads-share-dialog",
-                "width=626,height=600"
-              );
-            } catch (error) {
-              console.error("Error copying to clipboard:", error);
-              alert(
-                "Failed to copy card to clipboard. Please download it manually."
-              );
-            }
+            const postText =
+              "Just created my custom GitHub Universe Devémon card using Octocanvas from #GitHubUniverse 🎴";
+            const threadsUrl = `https://www.threads.net/intent/post?text=${encodeURIComponent(
+              postText
+            )}`;
+            window.open(
+              threadsUrl,
+              "threads-share-dialog",
+              "width=626,height=600"
+            );
+          } catch (error) {
+            console.error("Error copying to clipboard:", error);
+            alert(
+              "Failed to copy card to clipboard. Please download it manually."
+            );
           }
-        }, "image/png");
+        }
       } catch (error) {
         console.error("Error sharing to Threads:", error);
         alert("Failed to generate card image. Please try again.");
@@ -372,41 +335,33 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
       if (!cardRef.current) return;
 
       try {
-        const html2canvas = (await import("html2canvas")).default;
-        const canvas = await html2canvas(cardRef.current, {
-          backgroundColor: null,
-          scale: 3,
-          useCORS: true,
-          logging: false,
-        });
+        const blob = await elementToPngBlob(cardRef.current);
 
-        canvas.toBlob(async (blob) => {
-          if (blob) {
-            try {
-              await navigator.clipboard.write([
-                new ClipboardItem({ "image/png": blob }),
-              ]);
+        if (blob) {
+          try {
+            await navigator.clipboard.write([
+              new ClipboardItem({ "image/png": blob }),
+            ]);
 
-              alert(
-                "✅ Devémon card copied to clipboard!\n\n📱 To share on Instagram:\n1. Open the Instagram app on your device\n2. Tap the + button to create a new post\n3. Paste the image from your clipboard\n4. Add your caption and share!"
+            alert(
+              "✅ Devémon card copied to clipboard!\n\n📱 To share on Instagram:\n1. Open the Instagram app on your device\n2. Tap the + button to create a new post\n3. Paste the image from your clipboard\n4. Add your caption and share!"
+            );
+
+            window.location.href = "instagram://library";
+            setTimeout(() => {
+              window.open(
+                "https://www.instagram.com/",
+                "instagram-share",
+                "width=626,height=600"
               );
-
-              window.location.href = "instagram://library";
-              setTimeout(() => {
-                window.open(
-                  "https://www.instagram.com/",
-                  "instagram-share",
-                  "width=626,height=600"
-                );
-              }, 1500);
-            } catch (error) {
-              console.error("Error copying to clipboard:", error);
-              alert(
-                "Failed to copy card to clipboard. Please download it manually."
-              );
-            }
+            }, 1500);
+          } catch (error) {
+            console.error("Error copying to clipboard:", error);
+            alert(
+              "Failed to copy card to clipboard. Please download it manually."
+            );
           }
-        }, "image/png");
+        }
       } catch (error) {
         console.error("Error sharing to Instagram:", error);
         alert("Failed to generate card image. Please try again.");
@@ -432,6 +387,7 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
         <div className={styles.PreviewSection}>
           <div
             ref={cardRef}
+            data-devemon-card="true"
             className={styles.Card}
             style={{
               background: `linear-gradient(135deg, ${rarityInfo.color}15, ${rarityInfo.color}30)`,
@@ -465,9 +421,7 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                       color: rarityInfo.color,
                     }}
                   >
-                    <span className={styles.RarityBadgeText}>
-                      {rarityInfo.name.toUpperCase()}
-                    </span>
+                    {rarityInfo.name.toUpperCase()}
                   </span>
                 </div>
               </div>
@@ -499,14 +453,13 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                         data-open-to-work-badge="true"
                         className={styles.HireBadge}
                       >
-                        <span
-                          aria-hidden="true"
-                          data-briefcase-icon="true"
+                        <Icon
+                          name="briefcase"
+                          size={12}
+                          color="currentColor"
+                          label=""
                           className={styles.HireBadgeIcon}
-                        >
-                          <span className={styles.HireBadgeIconHandle} />
-                          <span className={styles.HireBadgeIconSeam} />
-                        </span>
+                        />
                         <span className={styles.HireBadgeText}>
                           OPEN TO WORK
                         </span>
@@ -528,7 +481,7 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                         color="currentColor"
                         label="Repositories"
                       />
-                      <span className={styles.StatLabelText}>Repositories</span>
+                      Repositories
                     </div>
                     <div className={styles.StatValue}>{user.public_repos}</div>
                   </div>
@@ -540,7 +493,7 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                         color="currentColor"
                         label="Followers"
                       />
-                      <span className={styles.StatLabelText}>Followers</span>
+                      Followers
                     </div>
                     <div className={styles.StatValue}>{user.followers}</div>
                   </div>
@@ -552,7 +505,7 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                         color="currentColor"
                         label="Stars"
                       />
-                      <span className={styles.StatLabelText}>Stars</span>
+                      Stars
                     </div>
                     <div className={styles.StatValue}>
                       {extendedStats.totalStars}
@@ -566,7 +519,7 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                         color="currentColor"
                         label="Forks"
                       />
-                      <span className={styles.StatLabelText}>Forks</span>
+                      Forks
                     </div>
                     <div className={styles.StatValue}>
                       {extendedStats.totalForks}
@@ -583,7 +536,7 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                       color="currentColor"
                       label="Contributions"
                     />
-                    <span className={styles.StatLabelText}>Contributions</span>
+                    Contributions
                   </div>
                   <div className={styles.StatValue}>
                     {user.contributions?.totalContributions || 0}
@@ -600,9 +553,7 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                         color="currentColor"
                         label="Languages"
                       />
-                      <span className={styles.StatLabelText}>
                       Languages Mastered
-                      </span>
                     </div>
                     <div className="flex flex-wrap gap-1.5">
                       {extendedStats.topLanguages.map((lang) => (
@@ -619,8 +570,8 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
               </div>
 
               {/* Footer */}
-              <div className={styles.CardFooter}>
-                <p className={styles.CardFooterText}>
+              <div className="mt-3 pt-2.5 border-t borderColor-muted text-center">
+                <p className="text-xs text-gray-400 font-mono">
                   Developer since {formattedDate}
                 </p>
               </div>
@@ -811,14 +762,11 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                           display: "inline-flex",
                           alignItems: "center",
                           justifyContent: "center",
-                          gap: "4px",
                           padding: "0 8px",
                           height: "24px",
-                          boxSizing: "border-box",
                           fontFamily: "monospace",
                           fontWeight: "500",
                           fontSize: "9px",
-                          lineHeight: "1",
                           textTransform: "uppercase",
                           letterSpacing: "0.05em",
                           borderRadius: "4px",
@@ -829,17 +777,19 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                           boxShadow: "0 2px 4px rgba(0, 0, 0, 0.3)",
                         }}
                       >
-                        <span
-                          aria-hidden="true"
-                          data-briefcase-icon="true"
-                          className={styles.HireBadgeIcon}
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 16 16"
+                          fill="currentColor"
+                          style={{
+                            width: "12px",
+                            height: "12px",
+                            marginRight: "4px",
+                          }}
                         >
-                          <span className={styles.HireBadgeIconHandle} />
-                          <span className={styles.HireBadgeIconSeam} />
-                        </span>
-                        <span className={styles.HireBadgeText}>
-                          OPEN TO WORK
-                        </span>
+                          <path d="M7.5 1.75C7.5.784 8.284 0 9.25 0h5.5c.966 0 1.75.784 1.75 1.75v11.5A1.75 1.75 0 0 1 14.75 15h-5.5a1.75 1.75 0 0 1-1.75-1.75V1.75zm1.75-.25a.25.25 0 0 0-.25.25v11.5c0 .138.112.25.25.25h5.5a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25h-5.5zM4.943 9.25A.75.75 0 0 1 4 8.5h-.2a1.55 1.55 0 0 0-1.55 1.55v5.2c0 .856.694 1.55 1.55 1.55h.2a.75.75 0 0 1 0 1.5h-.2A3.05 3.05 0 0 1 .75 15.25v-5.2A3.05 3.05 0 0 1 3.8 7h.2a.75.75 0 0 1 .75.75v1.5z" />
+                        </svg>
+                        OPEN TO WORK
                       </span>
                     </div>
                   )}

--- a/src/components/DevemonCard.tsx
+++ b/src/components/DevemonCard.tsx
@@ -495,7 +495,10 @@ const DevemonCard = forwardRef<DevemonCardRef, DevemonCardProps>(
                   {/* Available for Hire Badge */}
                   {availableForHire && (
                     <div className={styles.HireBadgeContainer}>
-                      <span className={styles.HireBadge}>
+                      <span
+                        data-open-to-work-badge="true"
+                        className={styles.HireBadge}
+                      >
                         <span
                           aria-hidden="true"
                           data-briefcase-icon="true"

--- a/src/components/ReadmeBanner.tsx
+++ b/src/components/ReadmeBanner.tsx
@@ -17,9 +17,14 @@ import { useImperativeHandle } from "preact/hooks";
 
 import type { GitHubUser } from "./GitHubWallpaperApp";
 import { Checkbox, PrimerSelect } from "./ui/FormControls";
+import { Icon } from "./ui/Icon";
 import { PrimaryButton, SecondaryButton } from "./ui/Button";
 import styles from "./ReadmeBanner.module.css";
 import sharedStyles from "./shared.module.css";
+import { downloadElementAsPng, elementToPngBlob } from "../utils/domExport";
+
+/** README banners are wide, so 2x keeps the exported file size reasonable. */
+const BANNER_EXPORT_SCALE = 2;
 
 export interface ReadmeBannerRef {
   downloadBanner: () => Promise<void>;
@@ -493,23 +498,11 @@ const ReadmeBanner = forwardRef<ReadmeBannerRef, ReadmeBannerProps>(
       if (!standardBannerRef.current) return;
 
       try {
-        const html2canvas = (await import("html2canvas")).default;
-        const canvas = await html2canvas(standardBannerRef.current, {
-          scale: 2,
-          backgroundColor: null,
-          useCORS: true,
-        });
-
-        canvas.toBlob((blob) => {
-          if (!blob) return;
-
-          const url = URL.createObjectURL(blob);
-          const link = document.createElement("a");
-          link.href = url;
-          link.download = `${user.login}-readme-banner.png`;
-          link.click();
-          URL.revokeObjectURL(url);
-        });
+        await downloadElementAsPng(
+          standardBannerRef.current,
+          `${user.login}-readme-banner.png`,
+          { scale: BANNER_EXPORT_SCALE }
+        );
       } catch (error) {
         console.error("Error generating banner:", error);
       }
@@ -542,42 +535,37 @@ const ReadmeBanner = forwardRef<ReadmeBannerRef, ReadmeBannerProps>(
       if (!standardBannerRef.current) return;
 
       try {
-        const html2canvas = (await import("html2canvas")).default;
-        const canvas = await html2canvas(standardBannerRef.current, {
-          scale: 2,
-          backgroundColor: null,
-          useCORS: true,
+        const blob = await elementToPngBlob(standardBannerRef.current, {
+          scale: BANNER_EXPORT_SCALE,
         });
 
-        canvas.toBlob(async (blob) => {
-          if (blob) {
-            try {
-              await navigator.clipboard.write([
-                new ClipboardItem({ "image/png": blob }),
-              ]);
+        if (blob) {
+          try {
+            await navigator.clipboard.write([
+              new ClipboardItem({ "image/png": blob }),
+            ]);
 
-              alert(
-                "✅ Banner copied to clipboard! You can now paste it in your tweet."
-              );
+            alert(
+              "✅ Banner copied to clipboard! You can now paste it in your tweet."
+            );
 
-              const tweetText =
-                "Just created my custom GitHub Universe README banner using Octocanvas from #GitHubUniverse 🎉";
-              const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-                tweetText
-              )}`;
-              window.open(
-                twitterUrl,
-                "twitter-share-dialog",
-                "width=626,height=436"
-              );
-            } catch (error) {
-              console.error("Error copying to clipboard:", error);
-              alert(
-                "Failed to copy banner to clipboard. Please download it manually."
-              );
-            }
+            const tweetText =
+              "Just created my custom GitHub Universe README banner using Octocanvas from #GitHubUniverse 🎉";
+            const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+              tweetText
+            )}`;
+            window.open(
+              twitterUrl,
+              "twitter-share-dialog",
+              "width=626,height=436"
+            );
+          } catch (error) {
+            console.error("Error copying to clipboard:", error);
+            alert(
+              "Failed to copy banner to clipboard. Please download it manually."
+            );
           }
-        }, "image/png");
+        }
       } catch (error) {
         console.error("Error sharing to Twitter:", error);
         alert("Failed to generate banner image. Please try again.");
@@ -591,42 +579,37 @@ const ReadmeBanner = forwardRef<ReadmeBannerRef, ReadmeBannerProps>(
       if (!standardBannerRef.current) return;
 
       try {
-        const html2canvas = (await import("html2canvas")).default;
-        const canvas = await html2canvas(standardBannerRef.current, {
-          scale: 2,
-          backgroundColor: null,
-          useCORS: true,
+        const blob = await elementToPngBlob(standardBannerRef.current, {
+          scale: BANNER_EXPORT_SCALE,
         });
 
-        canvas.toBlob(async (blob) => {
-          if (blob) {
-            try {
-              await navigator.clipboard.write([
-                new ClipboardItem({ "image/png": blob }),
-              ]);
+        if (blob) {
+          try {
+            await navigator.clipboard.write([
+              new ClipboardItem({ "image/png": blob }),
+            ]);
 
-              alert(
-                "✅ Banner copied to clipboard! You can now paste it in your Bluesky post."
-              );
+            alert(
+              "✅ Banner copied to clipboard! You can now paste it in your Bluesky post."
+            );
 
-              const postText =
-                "Just created my custom GitHub Universe README banner using Octocanvas from #GitHubUniverse 🎉";
-              const blueskyUrl = `https://bsky.app/intent/compose?text=${encodeURIComponent(
-                postText
-              )}`;
-              window.open(
-                blueskyUrl,
-                "bluesky-share-dialog",
-                "width=626,height=600"
-              );
-            } catch (error) {
-              console.error("Error copying to clipboard:", error);
-              alert(
-                "Failed to copy banner to clipboard. Please download it manually."
-              );
-            }
+            const postText =
+              "Just created my custom GitHub Universe README banner using Octocanvas from #GitHubUniverse 🎉";
+            const blueskyUrl = `https://bsky.app/intent/compose?text=${encodeURIComponent(
+              postText
+            )}`;
+            window.open(
+              blueskyUrl,
+              "bluesky-share-dialog",
+              "width=626,height=600"
+            );
+          } catch (error) {
+            console.error("Error copying to clipboard:", error);
+            alert(
+              "Failed to copy banner to clipboard. Please download it manually."
+            );
           }
-        }, "image/png");
+        }
       } catch (error) {
         console.error("Error sharing to Bluesky:", error);
         alert("Failed to generate banner image. Please try again.");
@@ -640,42 +623,37 @@ const ReadmeBanner = forwardRef<ReadmeBannerRef, ReadmeBannerProps>(
       if (!standardBannerRef.current) return;
 
       try {
-        const html2canvas = (await import("html2canvas")).default;
-        const canvas = await html2canvas(standardBannerRef.current, {
-          scale: 2,
-          backgroundColor: null,
-          useCORS: true,
+        const blob = await elementToPngBlob(standardBannerRef.current, {
+          scale: BANNER_EXPORT_SCALE,
         });
 
-        canvas.toBlob(async (blob) => {
-          if (blob) {
-            try {
-              await navigator.clipboard.write([
-                new ClipboardItem({ "image/png": blob }),
-              ]);
+        if (blob) {
+          try {
+            await navigator.clipboard.write([
+              new ClipboardItem({ "image/png": blob }),
+            ]);
 
-              alert(
-                "✅ Banner copied to clipboard! You can now paste it in your Threads post."
-              );
+            alert(
+              "✅ Banner copied to clipboard! You can now paste it in your Threads post."
+            );
 
-              const postText =
-                "Just created my custom GitHub Universe README banner using Octocanvas from #GitHubUniverse 🎉";
-              const threadsUrl = `https://www.threads.net/intent/post?text=${encodeURIComponent(
-                postText
-              )}`;
-              window.open(
-                threadsUrl,
-                "threads-share-dialog",
-                "width=626,height=600"
-              );
-            } catch (error) {
-              console.error("Error copying to clipboard:", error);
-              alert(
-                "Failed to copy banner to clipboard. Please download it manually."
-              );
-            }
+            const postText =
+              "Just created my custom GitHub Universe README banner using Octocanvas from #GitHubUniverse 🎉";
+            const threadsUrl = `https://www.threads.net/intent/post?text=${encodeURIComponent(
+              postText
+            )}`;
+            window.open(
+              threadsUrl,
+              "threads-share-dialog",
+              "width=626,height=600"
+            );
+          } catch (error) {
+            console.error("Error copying to clipboard:", error);
+            alert(
+              "Failed to copy banner to clipboard. Please download it manually."
+            );
           }
-        }, "image/png");
+        }
       } catch (error) {
         console.error("Error sharing to Threads:", error);
         alert("Failed to generate banner image. Please try again.");
@@ -689,40 +667,35 @@ const ReadmeBanner = forwardRef<ReadmeBannerRef, ReadmeBannerProps>(
       if (!standardBannerRef.current) return;
 
       try {
-        const html2canvas = (await import("html2canvas")).default;
-        const canvas = await html2canvas(standardBannerRef.current, {
-          scale: 2,
-          backgroundColor: null,
-          useCORS: true,
+        const blob = await elementToPngBlob(standardBannerRef.current, {
+          scale: BANNER_EXPORT_SCALE,
         });
 
-        canvas.toBlob(async (blob) => {
-          if (blob) {
-            try {
-              await navigator.clipboard.write([
-                new ClipboardItem({ "image/png": blob }),
-              ]);
+        if (blob) {
+          try {
+            await navigator.clipboard.write([
+              new ClipboardItem({ "image/png": blob }),
+            ]);
 
-              alert(
-                "✅ Banner copied to clipboard!\n\n📱 To share on Instagram:\n1. Open the Instagram app on your device\n2. Tap the + button to create a new post\n3. Paste the image from your clipboard\n4. Add your caption and share!"
-              );
+            alert(
+              "✅ Banner copied to clipboard!\n\n📱 To share on Instagram:\n1. Open the Instagram app on your device\n2. Tap the + button to create a new post\n3. Paste the image from your clipboard\n4. Add your caption and share!"
+            );
 
-              window.location.href = "instagram://library";
-              setTimeout(() => {
-                window.open(
-                  "https://www.instagram.com/",
-                  "instagram-share",
-                  "width=626,height=600"
-                );
-              }, 1500);
-            } catch (error) {
-              console.error("Error copying to clipboard:", error);
-              alert(
-                "Failed to copy banner to clipboard. Please download it manually."
+            window.location.href = "instagram://library";
+            setTimeout(() => {
+              window.open(
+                "https://www.instagram.com/",
+                "instagram-share",
+                "width=626,height=600"
               );
-            }
+            }, 1500);
+          } catch (error) {
+            console.error("Error copying to clipboard:", error);
+            alert(
+              "Failed to copy banner to clipboard. Please download it manually."
+            );
           }
-        }, "image/png");
+        }
       } catch (error) {
         console.error("Error sharing to Instagram:", error);
         alert("Failed to generate banner image. Please try again.");
@@ -960,60 +933,15 @@ const ReadmeBanner = forwardRef<ReadmeBannerRef, ReadmeBannerProps>(
                               fontSize: "14px",
                               fontWeight: "500",
                               fontFamily: "monospace",
-                              lineHeight: "1",
-                              display: "inline-flex",
-                              alignItems: "center",
-                              gap: "8px",
                             }}
                           >
-                            <span
-                              aria-hidden="true"
-                              style={{
-                                position: "relative",
-                                width: "16px",
-                                height: "12px",
-                                display: "block",
-                                flexShrink: 0,
-                                boxSizing: "border-box",
-                                marginTop: "4px",
-                                border: "2px solid currentColor",
-                                borderRadius: "2px",
-                              }}
-                            >
-                              <span
-                                style={{
-                                  position: "absolute",
-                                  left: "4px",
-                                  top: "-7px",
-                                  display: "block",
-                                  width: "8px",
-                                  height: "7px",
-                                  boxSizing: "border-box",
-                                  border: "2px solid currentColor",
-                                  borderBottom: 0,
-                                  borderRadius: "3px 3px 0 0",
-                                }}
-                              />
-                              <span
-                                style={{
-                                  position: "absolute",
-                                  left: "-2px",
-                                  right: "-2px",
-                                  top: "4px",
-                                  display: "block",
-                                  borderTop: "2px solid currentColor",
-                                }}
-                              />
-                            </span>
-                            <span
-                              style={{
-                                display: "block",
-                                lineHeight: "1",
-                                transform: "translateY(-1px)",
-                              }}
-                            >
-                              OPEN TO WORK
-                            </span>
+                            <Icon
+                              name="briefcase"
+                              size="functional"
+                              color="currentColor"
+                              label="Available for Hire"
+                            />{" "}
+                            OPEN TO WORK
                           </div>
                         )}
                       </div>

--- a/src/components/ReadmeBanner.tsx
+++ b/src/components/ReadmeBanner.tsx
@@ -17,7 +17,6 @@ import { useImperativeHandle } from "preact/hooks";
 
 import type { GitHubUser } from "./GitHubWallpaperApp";
 import { Checkbox, PrimerSelect } from "./ui/FormControls";
-import { Icon } from "./ui/Icon";
 import { PrimaryButton, SecondaryButton } from "./ui/Button";
 import styles from "./ReadmeBanner.module.css";
 import sharedStyles from "./shared.module.css";
@@ -961,15 +960,60 @@ const ReadmeBanner = forwardRef<ReadmeBannerRef, ReadmeBannerProps>(
                               fontSize: "14px",
                               fontWeight: "500",
                               fontFamily: "monospace",
+                              lineHeight: "1",
+                              display: "inline-flex",
+                              alignItems: "center",
+                              gap: "8px",
                             }}
                           >
-                            <Icon
-                              name="briefcase"
-                              size="functional"
-                              color="currentColor"
-                              label="Available for Hire"
-                            />{" "}
-                            OPEN TO WORK
+                            <span
+                              aria-hidden="true"
+                              style={{
+                                position: "relative",
+                                width: "16px",
+                                height: "12px",
+                                display: "block",
+                                flexShrink: 0,
+                                boxSizing: "border-box",
+                                marginTop: "4px",
+                                border: "2px solid currentColor",
+                                borderRadius: "2px",
+                              }}
+                            >
+                              <span
+                                style={{
+                                  position: "absolute",
+                                  left: "4px",
+                                  top: "-7px",
+                                  display: "block",
+                                  width: "8px",
+                                  height: "7px",
+                                  boxSizing: "border-box",
+                                  border: "2px solid currentColor",
+                                  borderBottom: 0,
+                                  borderRadius: "3px 3px 0 0",
+                                }}
+                              />
+                              <span
+                                style={{
+                                  position: "absolute",
+                                  left: "-2px",
+                                  right: "-2px",
+                                  top: "4px",
+                                  display: "block",
+                                  borderTop: "2px solid currentColor",
+                                }}
+                              />
+                            </span>
+                            <span
+                              style={{
+                                display: "block",
+                                lineHeight: "1",
+                                transform: "translateY(-1px)",
+                              }}
+                            >
+                              OPEN TO WORK
+                            </span>
                           </div>
                         )}
                       </div>

--- a/src/utils/domExport.ts
+++ b/src/utils/domExport.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared DOM-to-PNG export helper.
+ *
+ * Every download and social share rasterizes the exact DOM the user is looking at, so
+ * the exported PNG has to be a faithful copy of the on-screen card/banner.
+ *
+ * `html2canvas` reimplements layout and text painting itself, which makes it drift from
+ * the browser. It paints every text run at `textRect.top + <its own font baseline
+ * probe>`, and with the Monaspace Neon / Mona Sans webfonts used here that probe
+ * overshoots the real ascent by roughly half an em. The result was that every label
+ * sank a few pixels inside its pill or stat cell (issue #59). It also cannot parse the
+ * `oklch()` colors Tailwind v4 emits, and it drops CSS filters such as the avatar glow.
+ *
+ * Instead we serialize the node into an SVG `<foreignObject>` and let the browser
+ * rasterize it. Layout, font metrics, filters and colors are then produced by the very
+ * same engine that painted the preview, so the export matches the preview by
+ * construction rather than by per-element pixel nudging.
+ */
+
+/** Default scale so downloads stay crisp on hi-dpi displays. */
+export const DEFAULT_EXPORT_SCALE = 3;
+
+export interface ExportOptions {
+  /** Pixel ratio of the exported image. */
+  scale?: number;
+}
+
+/**
+ * Render a DOM element to a canvas using the browser's own rendering engine.
+ */
+export async function elementToCanvas(
+  element: HTMLElement,
+  { scale = DEFAULT_EXPORT_SCALE }: ExportOptions = {},
+): Promise<HTMLCanvasElement> {
+  const { domToCanvas } = await import("modern-screenshot");
+
+  return domToCanvas(element, {
+    scale,
+    backgroundColor: null,
+  });
+}
+
+/**
+ * Render a DOM element to a PNG blob.
+ */
+export async function elementToPngBlob(
+  element: HTMLElement,
+  options: ExportOptions = {},
+): Promise<Blob | null> {
+  const canvas = await elementToCanvas(element, options);
+
+  return new Promise<Blob | null>((resolve) => {
+    canvas.toBlob((blob) => resolve(blob), "image/png");
+  });
+}
+
+/**
+ * Render a DOM element to a PNG and trigger a browser download.
+ */
+export async function downloadElementAsPng(
+  element: HTMLElement,
+  fileName: string,
+  options: ExportOptions = {},
+): Promise<void> {
+  const blob = await elementToPngBlob(element, options);
+  if (!blob) return;
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/tests/devemon-download-layout.spec.ts
+++ b/tests/devemon-download-layout.spec.ts
@@ -88,6 +88,17 @@ test("Devemon downloads keep the Open to Work badge aligned", async ({
     "color",
     "rgb(1, 4, 9)"
   );
+  const headerSpacing = await page.evaluate(() => {
+    const username = document.querySelector('[class*="Username"]');
+    const rarity = document.querySelector('[class*="RarityBadge"]');
+    const usernameRect = username?.getBoundingClientRect();
+    const rarityRect = rarity?.getBoundingClientRect();
+
+    return usernameRect && rarityRect
+      ? rarityRect.top - usernameRect.bottom
+      : Number.NaN;
+  });
+  expect(headerSpacing).toBeGreaterThanOrEqual(6);
 
   const exportBadgeMetrics = await page.evaluate(() => {
     const exportBadge = [...document.querySelectorAll("span")].find(

--- a/tests/devemon-download-layout.spec.ts
+++ b/tests/devemon-download-layout.spec.ts
@@ -84,6 +84,10 @@ test("Devemon downloads keep the Open to Work badge aligned", async ({
   await page.locator("label", { hasText: "Available for Hire" }).click();
   await expect(page.locator('[class*="RarityBadgeText"]')).toBeVisible();
   await expect(page.locator('[class*="StatLabelText"]')).toHaveCount(6);
+  await expect(page.locator('[data-open-to-work-badge="true"]')).toHaveCSS(
+    "color",
+    "rgb(1, 4, 9)"
+  );
 
   const exportBadgeMetrics = await page.evaluate(() => {
     const exportBadge = [...document.querySelectorAll("span")].find(

--- a/tests/devemon-download-layout.spec.ts
+++ b/tests/devemon-download-layout.spec.ts
@@ -1,5 +1,19 @@
-import { expect, test, type Page } from "@playwright/test";
+/**
+ * Export fidelity regression tests (issue #59).
+ *
+ * Downloads are produced from the same DOM the user is looking at, so an exported PNG
+ * must be a faithful copy of the on-screen render. The previous renderer reimplemented
+ * text layout and painted every label a few pixels too low, which pushed pill labels
+ * like "LEGENDARY" and "OPEN TO WORK" to the bottom of their pills.
+ *
+ * These tests compare the real download against a browser screenshot of the same node,
+ * so any renderer that reinvents layout or text metrics fails loudly.
+ */
+import { expect, test, type Locator, type Page } from "@playwright/test";
 import { readFile } from "node:fs/promises";
+
+/** Exports render at 3x, so screenshot at 3x to compare like for like. */
+test.use({ deviceScaleFactor: 3 });
 
 const avatarDataUrl =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
@@ -42,15 +56,7 @@ async function mockGitHubProfile(page: Page) {
         total_contributions: 123,
         weeks: [
           {
-            contribution_days: [
-              { count: 1 },
-              { count: 2 },
-              { count: 3 },
-              { count: 4 },
-              { count: 5 },
-              { count: 6 },
-              { count: 7 },
-            ],
+            contribution_days: [{ count: 1 }, { count: 2 }, { count: 3 }],
           },
         ],
       }),
@@ -58,9 +64,21 @@ async function mockGitHubProfile(page: Page) {
   });
 }
 
-async function readPngDimensions(path: string) {
-  const buffer = await readFile(path);
+async function generateProfile(page: Page) {
+  await page.goto("/", { waitUntil: "networkidle" });
+  const usernameInput = page.getByLabel("GitHub Username");
+  await usernameInput.fill("octocat");
+  await expect(usernameInput).toHaveValue("octocat");
+  await page.getByRole("button", { name: /generate/i }).click();
+  await expect(page.getByText("@octocat").first()).toBeVisible();
+}
+
+function assertPngHeader(buffer: Buffer) {
   expect(buffer.subarray(0, 8).toString("hex")).toBe("89504e470d0a1a0a");
+}
+
+function readPngDimensions(buffer: Buffer) {
+  assertPngHeader(buffer);
 
   return {
     width: buffer.readUInt32BE(16),
@@ -68,90 +86,111 @@ async function readPngDimensions(path: string) {
   };
 }
 
-test("Devemon downloads keep the Open to Work badge aligned", async ({
+/**
+ * Compare an exported PNG against a screenshot of the element it was rendered from.
+ *
+ * Both images come from the same browser at the same scale, so a faithful export only
+ * differs by sub-pixel antialiasing. A renderer that lays text out itself shifts entire
+ * glyph runs and blows past the threshold.
+ */
+async function comparePngToElement(page: Page, png: Buffer, element: Locator) {
+  const reference = await element.screenshot();
+
+  return page.evaluate(
+    async ([exportedB64, referenceB64]) => {
+      const load = (b64: string) =>
+        new Promise<HTMLImageElement>((resolve, reject) => {
+          const image = new Image();
+          image.onload = () => resolve(image);
+          image.onerror = reject;
+          image.src = `data:image/png;base64,${b64}`;
+        });
+
+      const [exported, expected] = await Promise.all([
+        load(exportedB64),
+        load(referenceB64),
+      ]);
+
+      // Rounding can differ by a pixel; compare the shared region.
+      const width = Math.min(exported.width, expected.width);
+      const height = Math.min(exported.height, expected.height);
+
+      const pixels = (image: HTMLImageElement) => {
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        const context = canvas.getContext("2d")!;
+        context.drawImage(image, 0, 0);
+        return context.getImageData(0, 0, width, height).data;
+      };
+
+      const a = pixels(exported);
+      const b = pixels(expected);
+
+      let differing = 0;
+      for (let i = 0; i < a.length; i += 4) {
+        const delta =
+          Math.abs(a[i] - b[i]) +
+          Math.abs(a[i + 1] - b[i + 1]) +
+          Math.abs(a[i + 2] - b[i + 2]);
+        if (delta > 30) differing++;
+      }
+
+      return {
+        differingPercent: (differing / (width * height)) * 100,
+        exported: { width: exported.width, height: exported.height },
+        expected: { width: expected.width, height: expected.height },
+      };
+    },
+    [png.toString("base64"), reference.toString("base64")] as const
+  );
+}
+
+test("Devemon card download matches the on-screen card", async ({
   page,
 }, testInfo) => {
   await mockGitHubProfile(page);
-
-  await page.goto("/", { waitUntil: "networkidle" });
-  const usernameInput = page.getByLabel("GitHub Username");
-  await usernameInput.fill("octocat");
-  await expect(usernameInput).toHaveValue("octocat");
-  await page.getByRole("button", { name: /generate/i }).click();
-  await expect(page.getByText("@octocat").first()).toBeVisible();
+  await generateProfile(page);
 
   await page.getByRole("tab", { name: /devémon/i }).click();
   await page.locator("label", { hasText: "Available for Hire" }).click();
-  await expect(page.locator('[class*="RarityBadgeText"]')).toBeVisible();
-  await expect(page.locator('[class*="StatLabelText"]')).toHaveCount(6);
+
+  const rarityBadge = page.locator('[class*="RarityBadge"]').first();
+  await expect(rarityBadge).toBeVisible();
+
+  // The rarity pill sits on the same line as "@login"; both must share a center line.
+  // A renderer that sinks text makes the pill look like it floats above the handle.
+  const headerAlignment = await page.evaluate(() => {
+    const login = document.querySelector('[class*="DisplayName"]');
+    const rarity = document.querySelector('[class*="RarityBadge"]');
+    if (!login || !rarity) return null;
+
+    const center = (element: Element) => {
+      const rect = element.getBoundingClientRect();
+      return (rect.top + rect.bottom) / 2;
+    };
+
+    const usernameRect = document
+      .querySelector('[class*="Username"]')!
+      .getBoundingClientRect();
+
+    return {
+      centerDelta: Math.abs(center(rarity) - center(login)),
+      gapUnderUsername:
+        rarity.getBoundingClientRect().top - usernameRect.bottom,
+    };
+  });
+
+  expect(headerAlignment).not.toBeNull();
+  expect(headerAlignment!.centerDelta).toBeLessThanOrEqual(1);
+  // The pill must never ride up into the display name.
+  expect(headerAlignment!.gapUnderUsername).toBeGreaterThan(0);
+
+  // "OPEN TO WORK" sits on the bright brand-green pill, so it needs dark text.
   await expect(page.locator('[data-open-to-work-badge="true"]')).toHaveCSS(
     "color",
     "rgb(1, 4, 9)"
   );
-  const headerSpacing = await page.evaluate(() => {
-    const username = document.querySelector('[class*="Username"]');
-    const rarity = document.querySelector('[class*="RarityBadge"]');
-    const usernameRect = username?.getBoundingClientRect();
-    const rarityRect = rarity?.getBoundingClientRect();
-
-    return usernameRect && rarityRect
-      ? rarityRect.top - usernameRect.bottom
-      : Number.NaN;
-  });
-  expect(headerSpacing).toBeGreaterThanOrEqual(6);
-
-  const exportBadgeMetrics = await page.evaluate(() => {
-    const exportBadge = [...document.querySelectorAll("span")].find(
-      (element) =>
-        element.textContent?.includes("OPEN TO WORK") &&
-        element.getBoundingClientRect().x < -1000
-    );
-
-    if (!exportBadge) {
-      return null;
-    }
-
-    const badgeRect = exportBadge.getBoundingClientRect();
-    const icon = exportBadge.querySelector('[data-briefcase-icon="true"]');
-    const iconRect = icon?.getBoundingClientRect();
-
-    return {
-      display: getComputedStyle(exportBadge).display,
-      alignItems: getComputedStyle(exportBadge).alignItems,
-      gap: getComputedStyle(exportBadge).gap,
-      iconTag: icon?.tagName,
-      iconWidth: iconRect?.width,
-      iconHeight: iconRect?.height,
-      iconCenterDelta: iconRect
-        ? Math.abs(
-            iconRect.y +
-              iconRect.height / 2 -
-              (badgeRect.y + badgeRect.height / 2)
-          )
-        : Number.NaN,
-    };
-  });
-
-  expect(exportBadgeMetrics).toMatchObject({
-    display: "inline-flex",
-    alignItems: "center",
-    gap: "4px",
-  });
-  expect(exportBadgeMetrics?.iconTag).toBe("SPAN");
-  expect(exportBadgeMetrics?.iconWidth).toBe(12);
-  expect(exportBadgeMetrics?.iconHeight).toBe(10);
-  expect(exportBadgeMetrics?.iconCenterDelta).toBeLessThanOrEqual(1);
-
-  const [badgeDownload] = await Promise.all([
-    page.waitForEvent("download"),
-    page.getByRole("button", { name: /download badge/i }).click(),
-  ]);
-  const badgePath = testInfo.outputPath("devemon-badge.png");
-  await badgeDownload.saveAs(badgePath);
-  const badgeDimensions = await readPngDimensions(badgePath);
-  expect(badgeDimensions.width).toBe(960);
-  expect(badgeDimensions.height).toBeGreaterThanOrEqual(720);
-  expect(badgeDimensions.height).toBeLessThanOrEqual(723);
 
   const [cardDownload] = await Promise.all([
     page.waitForEvent("download"),
@@ -159,8 +198,58 @@ test("Devemon downloads keep the Open to Work badge aligned", async ({
   ]);
   const cardPath = testInfo.outputPath("devemon-card.png");
   await cardDownload.saveAs(cardPath);
-  const cardDimensions = await readPngDimensions(cardPath);
-  expect(cardDimensions.width).toBeGreaterThanOrEqual(900);
-  expect(cardDimensions.width).toBeLessThanOrEqual(920);
-  expect(cardDimensions.height).toBe(1650);
+  const cardPng = await readFile(cardPath);
+
+  const { width, height } = readPngDimensions(cardPng);
+  expect(width).toBeGreaterThan(0);
+  expect(height).toBeGreaterThan(0);
+
+  const card = page.locator('[data-devemon-card="true"]');
+  await expect(card).toBeVisible();
+  const comparison = await comparePngToElement(page, cardPng, card);
+
+  // Exported and on-screen renders line up to within antialiasing noise.
+  expect(comparison.differingPercent).toBeLessThan(8);
+});
+
+test("Devemon badge download produces a valid PNG", async ({
+  page,
+}, testInfo) => {
+  await mockGitHubProfile(page);
+  await generateProfile(page);
+
+  await page.getByRole("tab", { name: /devémon/i }).click();
+  await page.locator("label", { hasText: "Available for Hire" }).click();
+  await expect(page.locator('[class*="RarityBadge"]').first()).toBeVisible();
+
+  const [badgeDownload] = await Promise.all([
+    page.waitForEvent("download"),
+    page.getByRole("button", { name: /download badge/i }).click(),
+  ]);
+  const badgePath = testInfo.outputPath("devemon-badge.png");
+  await badgeDownload.saveAs(badgePath);
+
+  const { width, height } = readPngDimensions(await readFile(badgePath));
+  expect(width).toBeGreaterThan(0);
+  expect(height).toBeGreaterThan(0);
+});
+
+test("README banner download produces a valid PNG", async ({
+  page,
+}, testInfo) => {
+  await mockGitHubProfile(page);
+  await generateProfile(page);
+
+  await page.getByRole("tab", { name: /banner/i }).click();
+
+  const [bannerDownload] = await Promise.all([
+    page.waitForEvent("download"),
+    page.getByRole("button", { name: "Download", exact: true }).click(),
+  ]);
+  const bannerPath = testInfo.outputPath("readme-banner.png");
+  await bannerDownload.saveAs(bannerPath);
+
+  const { width, height } = readPngDimensions(await readFile(bannerPath));
+  expect(width).toBeGreaterThan(0);
+  expect(height).toBeGreaterThan(0);
 });

--- a/tests/devemon-download-layout.spec.ts
+++ b/tests/devemon-download-layout.spec.ts
@@ -82,6 +82,8 @@ test("Devemon downloads keep the Open to Work badge aligned", async ({
 
   await page.getByRole("tab", { name: /devémon/i }).click();
   await page.locator("label", { hasText: "Available for Hire" }).click();
+  await expect(page.locator('[class*="RarityBadgeText"]')).toBeVisible();
+  await expect(page.locator('[class*="StatLabelText"]')).toHaveCount(6);
 
   const exportBadgeMetrics = await page.evaluate(() => {
     const exportBadge = [...document.querySelectorAll("span")].find(
@@ -131,10 +133,10 @@ test("Devemon downloads keep the Open to Work badge aligned", async ({
   ]);
   const badgePath = testInfo.outputPath("devemon-badge.png");
   await badgeDownload.saveAs(badgePath);
-  expect(await readPngDimensions(badgePath)).toEqual({
-    width: 960,
-    height: 720,
-  });
+  const badgeDimensions = await readPngDimensions(badgePath);
+  expect(badgeDimensions.width).toBe(960);
+  expect(badgeDimensions.height).toBeGreaterThanOrEqual(720);
+  expect(badgeDimensions.height).toBeLessThanOrEqual(723);
 
   const [cardDownload] = await Promise.all([
     page.waitForEvent("download"),
@@ -142,8 +144,8 @@ test("Devemon downloads keep the Open to Work badge aligned", async ({
   ]);
   const cardPath = testInfo.outputPath("devemon-card.png");
   await cardDownload.saveAs(cardPath);
-  expect(await readPngDimensions(cardPath)).toEqual({
-    width: 912,
-    height: 1650,
-  });
+  const cardDimensions = await readPngDimensions(cardPath);
+  expect(cardDimensions.width).toBeGreaterThanOrEqual(900);
+  expect(cardDimensions.width).toBeLessThanOrEqual(920);
+  expect(cardDimensions.height).toBe(1650);
 });

--- a/tests/devemon-download-layout.spec.ts
+++ b/tests/devemon-download-layout.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test, type Page } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+
+const avatarDataUrl =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+async function mockGitHubProfile(page: Page) {
+  await page.route("https://api.github.com/users/octocat", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        login: "octocat",
+        name: "The Octocat",
+        avatar_url: avatarDataUrl,
+        html_url: "https://github.com/octocat",
+        followers: 42,
+        public_repos: 8,
+        bio: "GitHub mascot",
+        created_at: "2011-01-25T18:44:36Z",
+      }),
+    });
+  });
+
+  await page.route(
+    "https://api.github.com/users/octocat/repos?per_page=100&sort=updated",
+    async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify([
+          { stargazers_count: 10, forks_count: 2, language: "TypeScript" },
+          { stargazers_count: 4, forks_count: 1, language: "CSS" },
+          { stargazers_count: 1, forks_count: 0, language: "TypeScript" },
+        ]),
+      });
+    }
+  );
+
+  await page.route("https://github.com/octocat.contribs", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        total_contributions: 123,
+        weeks: [
+          {
+            contribution_days: [
+              { count: 1 },
+              { count: 2 },
+              { count: 3 },
+              { count: 4 },
+              { count: 5 },
+              { count: 6 },
+              { count: 7 },
+            ],
+          },
+        ],
+      }),
+    });
+  });
+}
+
+async function readPngDimensions(path: string) {
+  const buffer = await readFile(path);
+  expect(buffer.subarray(0, 8).toString("hex")).toBe("89504e470d0a1a0a");
+
+  return {
+    width: buffer.readUInt32BE(16),
+    height: buffer.readUInt32BE(20),
+  };
+}
+
+test("Devemon downloads keep the Open to Work badge aligned", async ({
+  page,
+}, testInfo) => {
+  await mockGitHubProfile(page);
+
+  await page.goto("/", { waitUntil: "networkidle" });
+  const usernameInput = page.getByLabel("GitHub Username");
+  await usernameInput.fill("octocat");
+  await expect(usernameInput).toHaveValue("octocat");
+  await page.getByRole("button", { name: /generate/i }).click();
+  await expect(page.getByText("@octocat").first()).toBeVisible();
+
+  await page.getByRole("tab", { name: /devémon/i }).click();
+  await page.locator("label", { hasText: "Available for Hire" }).click();
+
+  const exportBadgeMetrics = await page.evaluate(() => {
+    const exportBadge = [...document.querySelectorAll("span")].find(
+      (element) =>
+        element.textContent?.includes("OPEN TO WORK") &&
+        element.getBoundingClientRect().x < -1000
+    );
+
+    if (!exportBadge) {
+      return null;
+    }
+
+    const badgeRect = exportBadge.getBoundingClientRect();
+    const icon = exportBadge.querySelector('[data-briefcase-icon="true"]');
+    const iconRect = icon?.getBoundingClientRect();
+
+    return {
+      display: getComputedStyle(exportBadge).display,
+      alignItems: getComputedStyle(exportBadge).alignItems,
+      gap: getComputedStyle(exportBadge).gap,
+      iconTag: icon?.tagName,
+      iconWidth: iconRect?.width,
+      iconHeight: iconRect?.height,
+      iconCenterDelta: iconRect
+        ? Math.abs(
+            iconRect.y +
+              iconRect.height / 2 -
+              (badgeRect.y + badgeRect.height / 2)
+          )
+        : Number.NaN,
+    };
+  });
+
+  expect(exportBadgeMetrics).toMatchObject({
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "4px",
+  });
+  expect(exportBadgeMetrics?.iconTag).toBe("SPAN");
+  expect(exportBadgeMetrics?.iconWidth).toBe(12);
+  expect(exportBadgeMetrics?.iconHeight).toBe(10);
+  expect(exportBadgeMetrics?.iconCenterDelta).toBeLessThanOrEqual(1);
+
+  const [badgeDownload] = await Promise.all([
+    page.waitForEvent("download"),
+    page.getByRole("button", { name: /download badge/i }).click(),
+  ]);
+  const badgePath = testInfo.outputPath("devemon-badge.png");
+  await badgeDownload.saveAs(badgePath);
+  expect(await readPngDimensions(badgePath)).toEqual({
+    width: 960,
+    height: 720,
+  });
+
+  const [cardDownload] = await Promise.all([
+    page.waitForEvent("download"),
+    page.getByRole("button", { name: /^download card$/i }).click(),
+  ]);
+  const cardPath = testInfo.outputPath("devemon-card.png");
+  await cardDownload.saveAs(cardPath);
+  expect(await readPngDimensions(cardPath)).toEqual({
+    width: 912,
+    height: 1650,
+  });
+});


### PR DESCRIPTION
Fixes #59

## Symptom

Downloaded PNGs didn't match what the browser rendered. Pill labels like **LEGENDARY** / **MYTHICAL** and **OPEN TO WORK** sank to the bottom of their pills, stat labels (`REPOSITORIES`, `FOLLOWERS`, `STARS`…) sat low in their cells, and the rarity pill looked like it floated above the `@login` handle instead of sharing a center line with it.

## Root cause

`html2canvas` reimplements text layout rather than deferring to the browser. It paints each text run at `textRect.top + <its own font baseline probe>`. With the Monaspace Neon / Mona Sans webfonts this project uses, that probe overshoots the real content-box ascent by roughly half an em:

| element | font-size | html2canvas baseline | real ascent | drift |
|---|---|---|---|---|
| Username | 20px | 29 | 19 | **+10** |
| @login | 14px | 22 | 15 | **+7** |
| RarityBadgeText | 14px | 21 | 13 | **+8** |
| StatLabelText | 11px | 16 | 10 | **+6** |

So *every* text run sank, while the pill **boxes** — which are real layout boxes — stayed where they belonged. That's why the pill read as "raised" relative to the handle: the pill was correct and the text around it had dropped.

This is why per-element `translateY` compensation was the wrong tool. It only ever patched a handful of the affected nodes, and the constants were specific to one font size and one viewport.

## Fix

Serialize the node into an SVG `<foreignObject>` and let the browser rasterize it ([`modern-screenshot`](https://github.com/qq15725/modern-screenshot), MIT). Layout, font metrics, CSS filters and colors are then produced by the *same engine that painted the preview*, so **export matches preview by construction** — no compensation constants anywhere.

Two things fall out of this for free:
- the Tailwind v4 `oklch()` parse failure goes away, so the `.CardFooter` CSS-module workaround is no longer needed;
- the avatar's `filter: blur()` glow renders again — `html2canvas` had been silently dropping it.

All ten export call sites (5 in `DevemonCard.tsx`, 5 in `ReadmeBanner.tsx`) now share `src/utils/domExport.ts`, which removes a good deal of duplicated boilerplate. `ReadmeBanner` keeps its original 2x scale; the Devémon card keeps 3x.

### Separately: an actually-undefined custom property

`--color-brand-on-primary` was referenced by `.HireBadge` / `.BadgeHireBadge` but **never declared** — not in `global.css`, not anywhere. An undefined custom property makes `color` inherit, which left near-invisible light text on the bright brand-green "OPEN TO WORK" pill in dark mode. Now uses `var(--color-bg-primary)`.

## Result

<img src="https://github.com/user-attachments/assets/094babb7-3309-4dbf-8091-fe6c726491f3" alt="Browser render vs downloaded PNG, side by side" width="720">

The downloaded card on its own:

<img src="https://github.com/user-attachments/assets/349ac9c0-0ba3-497e-ac16-e335a36b46a8" alt="Downloaded Devemon card after the fix" width="260">

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm run build` — clean
- `npx playwright test` — **4/4 passing**
- Measured export-vs-render difference: **1.41%** of pixels (pure antialiasing noise from a 1px width rounding difference), against an 8% assertion threshold.
- DOM `centerDelta` between the rarity pill and `@login` is now **0**.

`tests/devemon-download-layout.spec.ts` is rewritten to assert the property that actually matters: it triggers a **real download**, screenshots the same DOM node at the same 3x scale, and compares them pixel-by-pixel. That means it fails on *any* renderer that reinvents layout or text metrics, rather than asserting on incidental class names. Confirmed to have teeth — swapping the renderer back to `html2canvas` fails the test.

## Notes for reviewers

- **Dependency change:** removes `html2canvas`, adds `modern-screenshot@^4.7.0` (MIT, no transitive deps).
- The earlier commits on this branch introduced per-element nudging hacks; this commit resets those files and takes the root-cause route instead, so the net diff vs `main` is small (+143 lines, most of which is the new test).

